### PR TITLE
seafile webdav compatibility

### DIFF
--- a/davsync
+++ b/davsync
@@ -225,7 +225,7 @@ class WebDAVFileSystem (FileSystem) :
             fullPath = os.path.normpath('./' + os.path.join(path, name))
             last_modified = child.find('.//D:getlastmodified', self.xmlns)
             if last_modified is not None:
-                mtime = mtime = datetime.strptime(last_modified.text, RFC_1123_FORMAT)
+                mtime = datetime.strptime(last_modified.text, RFC_1123_FORMAT)
             else:
                 mtime = None
 

--- a/davsync
+++ b/davsync
@@ -223,7 +223,11 @@ class WebDAVFileSystem (FileSystem) :
             name = urllib2.unquote(child.find('D:href', self.xmlns).text)
 
             fullPath = os.path.normpath('./' + os.path.join(path, name))
-            mtime = datetime.strptime(child.find('.//D:getlastmodified', self.xmlns).text, RFC_1123_FORMAT)
+            last_modified = child.find('.//D:getlastmodified', self.xmlns)
+            if last_modified is not None:
+                mtime = mtime = datetime.strptime(last_modified.text, RFC_1123_FORMAT)
+            else:
+                mtime = None
 
             if self.isNodeCollection(child) :
                 d = Directory(fullPath, mtime)


### PR DESCRIPTION
Hi,

first of all: thanks for this great tool!
However, it did not work with seafile's webdav. The reason is that it does not send getlastmodified for folders. As this is not used in the algorithm anyway (as far as I can see) I just catch it and set mtime to None in this case